### PR TITLE
Update to take account the new directory scheme.

### DIFF
--- a/plugins/pocket/init.php
+++ b/plugins/pocket/init.php
@@ -22,7 +22,7 @@ class Pocket extends Plugin {
 	function hook_article_button($line) {
 		$article_id = $line["id"];
 
-		$rv = "<img src=\"plugins/pocket/pocket.png\"
+		$rv = "<img src=\"plugins.local/pocket/pocket.png\"
 			class='tagsPic' style=\"cursor : pointer\"
 			onclick=\"shareArticleToPocket($article_id)\"
 			title='".__('Pocket')."'>";


### PR DESCRIPTION
External plugins (not provided by tt-rss installation) have to be in plugins.local/ directory, because this one is ignored by git pull / push.