### PR TITLE
Update to take account the new directory scheme.

### DIFF
--- a/plugins/tweet/init.php
+++ b/plugins/tweet/init.php
@@ -22,7 +22,7 @@ class Tweet extends Plugin {
 	function hook_article_button($line) {
 		$article_id = $line["id"];
 
-		$rv = "<img src=\"plugins/tweet/tweet.png\"
+		$rv = "<img src=\"plugins.local/tweet/tweet.png\"
 			class='tagsPic' style=\"cursor : pointer\"
 			onclick=\"tweetArticle($article_id)\"
 			title='".__('Share on Twitter')."'>";


### PR DESCRIPTION
External plugins (not provided by tt-rss installation) have to be in plugins.local/ directory, because this one is ignored by git pull / push.